### PR TITLE
Add everypolitician-popolo to setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     install_requires = [
         'requests',
         'six >= 1.9.0',
+        'everypolitician-popolo == 0.0.2',
     ]
 )


### PR DESCRIPTION
When I `pip install everypolitician` and then try to import it, I get:

``` python
>>> from everypolitician import EveryPolitician
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/ep-thingy/env/lib/python3.4/site-packages/everypolitician/__init__.py", line 1, in <module>
    from .lib import *
  File "/ep-thingy/env/lib/python3.4/site-packages/everypolitician/lib.py", line 11, in <module>
    from popolo_data.importer import Popolo
ImportError: No module named 'popolo_data'
```

I _think_ it’s because it needs to be in the setup requirements? If so, this fixes that (albeit with v0.0.2).
